### PR TITLE
Fix initial setup and dependencies

### DIFF
--- a/ansible/roles/jetson_setup/tasks/cuda_setup.yml
+++ b/ansible/roles/jetson_setup/tasks/cuda_setup.yml
@@ -1,19 +1,31 @@
 ---
-- name: Mock CUDA setup (test mode)
-  ansible.builtin.debug:
-    msg: "Would configure CUDA {{ jetson_setup_cuda_version }} in test mode"
-  when: ansible_check_mode or is_test_mode
+- name: Install CUDA repository GPG key
+  ansible.builtin.apt_key:
+    url: "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/7fa2af80.pub"
+    state: present
+
+- name: Add CUDA repository
+  ansible.builtin.apt_repository:
+    repo: "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64 /"
+    state: present
+
+- name: Update apt cache
+  ansible.builtin.apt:
+    update_cache: yes
+
+- name: Install CUDA toolkit
+  ansible.builtin.apt:
+    name: "cuda-toolkit-{{ jetson_setup_cuda_version }}"
+    state: present
 
 - name: Configure CUDA environment
   ansible.builtin.template:
     src: cuda.sh.j2
     dest: /etc/profile.d/cuda.sh
     mode: "0644"
-  when: not ansible_check_mode and not is_test_mode
 
 - name: Update CUDA paths
   ansible.builtin.lineinfile:
     path: /etc/environment
     line: 'PATH=$PATH:/usr/local/cuda/bin'
     state: present
-  when: not ansible_check_mode and not is_test_mode

--- a/ansible/roles/jetson_setup/tasks/ml_libraries.yml
+++ b/ansible/roles/jetson_setup/tasks/ml_libraries.yml
@@ -1,18 +1,11 @@
 ---
-- name: Mock ML libraries setup (test mode)
-  ansible.builtin.debug:
-    msg: "Would configure ML libraries in test mode"
-  when: ansible_check_mode or is_test_mode
-
 - name: Install ML libraries
   ansible.builtin.package:
     name: "{{ jetson_setup_ml_libraries }}"
     state: present
-  when: not ansible_check_mode and not is_test_mode
 
 - name: Configure ML library paths
   ansible.builtin.template:
     src: ml_paths.conf.j2
     dest: /etc/ld.so.conf.d/nvidia-ml.conf
     mode: "0644"
-  when: not ansible_check_mode and not is_test_mode

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,8 @@ dependencies = [
     "requests>=2.32.3",
     "redis>=5.2.1",
     "kafka-python>=2.1.5",
+    "pulumi>=3.94.0",
+    "molecule>=6.0.2",
 ]
 
 [project.optional-dependencies]
@@ -41,7 +43,6 @@ dev = [
     "pytest>=7.0.0",
     "black>=23.0.0",
     "isort>=5.0.0",
-    "molecule>=6.0.2",
     "molecule-docker>=2.1.0",
     "docker>=6.1.3",
     "requests>=2.31.0",


### PR DESCRIPTION
Implement production mode tasks for CUDA and ML libraries setup in `ansible/roles/jetson_setup`.

* **CUDA Setup**:
  - Add tasks to install CUDA repository GPG key, add CUDA repository, update apt cache, and install CUDA toolkit.
  - Configure CUDA environment and update CUDA paths.

* **ML Libraries Setup**:
  - Add tasks to install ML libraries and configure ML library paths.

* **Dependencies**:
  - Move `pulumi` and `molecule` from optional to main dependencies in `pyproject.toml`.

Removed lots of mocking

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/SPRIME01/homelab-infra/pull/2?shareId=f9ccd4c1-3ff0-4fcf-aa34-f6be0a6d8f62).

## Summary by Sourcery

Implement production mode setup for CUDA and ML libraries on Jetson devices, and update project dependencies

New Features:
- Add production-ready tasks for CUDA toolkit installation and configuration

Enhancements:
- Remove test mode mocking from CUDA and ML libraries setup tasks

Build:
- Move `pulumi` and `molecule` from optional to main project dependencies in pyproject.toml